### PR TITLE
Add `tag:GetResources` on policy

### DIFF
--- a/elb-inline-policy.json
+++ b/elb-inline-policy.json
@@ -6,6 +6,11 @@
             "Effect": "Allow",
             "Action": "elasticloadbalancing:*",
             "Resource": "*"
+        },
+        {
+            "Effect" : "Allow",
+            "Action" : "tag:GetResources",
+            "Resource" : "*"
         }
     ]
 }


### PR DESCRIPTION
Without this addition getting the below error. 
```session.go:44] [ALB-INGRESS] [session] [ERROR]: Failed request: tagging/GetResources, Payload: {  ResourceTypeFilters: ["ec2"],  TagFilters: [{      Key: "kubernetes.io/role/internal-elb"    },{      Key: "kubernetes.io/cluster/eks",      Values: ["owned","shared"]    }]}, Error: AccessDeniedException: User: blahblahblah is not authorized to perform: tag:GetResources``` 
Not sure if this caused by the update I proposed to latest image, but this addition fixes the issue.